### PR TITLE
[S-4953] Bump default Meta Marketing API version to v25.0

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,7 +2,7 @@ package facebook
 
 type (
 	Config struct {
-		Version string       `envconfig:"VERSION" default:"v23.0"`
+		Version string       `envconfig:"VERSION" default:"v25.0"`
 		OAuth2  OAuth2Config `envconfig:"OAUTH2"`
 	}
 


### PR DESCRIPTION
## Summary
Bumps the default Meta Marketing API version from `v23.0` to `v25.0` in the
shared `facebook` SDK config.

Meta is deprecating all Marketing API versions prior to v24.0, and v24.0 itself
is now on the sunset path. This moves the default to the current stable v25.0.

## Change
- `config.go`: `Config.Version` default `v23.0` → `v25.0`

The version is still overridable via the `VERSION` env var, so any consumer can
pin a specific version if needed. `client.go` builds the OAuth `TokenURL` from
`cfg.Version`, so it picks up the new default automatically — no other code
changes required.

## Affected consumers
- `destinations` — **Dreamdata Conversions** (Conversions API) and
  **Dreamdata Audiences** (Custom Audiences API). Currently pinned to `v1.4.3`
  (which defaulted to v21.0) with no `VERSION` override, so it will move to
  v25.0 once it bumps to the new tag.

## Breaking-change review (v23 → v25)
Reviewed the Marketing API changelogs for v24 and v25 against the endpoints this
SDK actually calls (Conversions: `GET /{dataset}`, `GET /{adAccount}/adspixels`,
`POST /{dataset}/events`; Audiences: `GET`/`POST .../customaudiences`,
`POST /{audience}/users`, `GET /{audience}/sessions`; plus `/me`, `/me/adaccounts`).

**No breaking changes affect these operations.** The v24/v25 breaking changes
(Advantage+ campaign creation removal, Insights metric removals, `metadata=1`
deprecation, lookalike `lookalike_spec` requirement, async-job `error_code`
type change) all target endpoints this SDK does not use. The only audience-related
restriction (flagged customer-file audiences failing to update) is a policy
enforcement that applies across all API versions, not a v25 API change.